### PR TITLE
Useful things to make the edit look feature works

### DIFF
--- a/Controller/AutocompleteController.php
+++ b/Controller/AutocompleteController.php
@@ -108,7 +108,7 @@ class AutocompleteController extends AbstractController
     {
         $search = $request->query->get('search');
         if (false === empty($search)) {
-            $results = $this->tagManager->suggest($search, $request->getLocale());
+            $results = $this->tagManager->suggest($search, $request->query->get('language'));
             $count = min(10, count($results));
         } else {
             $page = $request->query->get('page', 1);

--- a/Controller/AutocompleteController.php
+++ b/Controller/AutocompleteController.php
@@ -98,7 +98,7 @@ class AutocompleteController extends AbstractController
     }
 
     /**
-     * @Route("/tag", name="autocomplete_tag")
+     * @Route("/tag", name="autocomplete_tag", options={"expose"=true})
      *
      * @param Request $request
      *

--- a/Manager/DesignerManager.php
+++ b/Manager/DesignerManager.php
@@ -176,7 +176,7 @@ class DesignerManager
      * @param string|null $language
      * @param string|null $country
      *
-     * @return array
+     * @return Designer[]
      */
     public function listFilters(
         ?string $type = null,
@@ -195,7 +195,10 @@ class DesignerManager
             RequestOptions::QUERY       => $query,
         ]);
         if ($apiResponse->getStatusCode() === Response::HTTP_OK) {
-            $results = json_decode((string) $apiResponse->getBody(), true);
+            $data = json_decode((string) $apiResponse->getBody(), true);
+            foreach ($data as $designer) {
+                $results[] = $this->serializer->denormalize($designer, Designer::class);
+            }
         }
 
         return $results;

--- a/Manager/MediaManager.php
+++ b/Manager/MediaManager.php
@@ -59,14 +59,8 @@ class MediaManager
      */
     private $serializer;
 
-    /**
-     * @param ApiProvider          $apiProvider
-     * @param SerializerInterface  $serializer
-     */
-    public function __construct(
-        ApiProvider $apiProvider,
-        SerializerInterface $serializer
-    ) {
+    public function __construct(ApiProvider $apiProvider, SerializerInterface $serializer)
+    {
         $this->apiProvider = $apiProvider;
         $this->serializer = $serializer;
     }
@@ -226,5 +220,19 @@ class MediaManager
         }
 
         return $updated;
+    }
+
+    public function suggestWatermarks(string $prefix): array
+    {
+        $apiResponse = $this->apiProvider->request(Request::METHOD_GET, '/api/medias/watermarks/suggestions', [
+            RequestOptions::HTTP_ERRORS => false,
+            RequestOptions::QUERY => compact('prefix')
+        ]);
+
+        if ($apiResponse->getStatusCode() !== Response::HTTP_OK) {
+            return [];
+        }
+
+        return json_decode($apiResponse->getBody());
     }
 }

--- a/Manager/TypeManager.php
+++ b/Manager/TypeManager.php
@@ -138,4 +138,34 @@ class TypeManager
 
         return $apiResponse->getStatusCode() === Response::HTTP_OK;
     }
+
+    /**
+     * @return Type[]
+     */
+    public function listFilters(
+        ?string $season = null,
+        ?string $city = null,
+        ?string $designer = null,
+        ?string $tags = null,
+        ?string $models = null,
+        ?string $language = null
+    ): array {
+        $query = array_filter(compact('season', 'city', 'designer', 'tags', 'models', 'language'));
+        $apiResponse = $this->apiProvider->request('GET', '/api/types/filter', [
+            RequestOptions::QUERY => $query,
+            RequestOptions::HTTP_ERRORS => false,
+        ]);
+
+        $results = [];
+        if ($apiResponse->getStatusCode() !== Response::HTTP_OK) {
+            return $results;
+        }
+
+        $data = json_decode((string) $apiResponse->getBody(), true);
+        foreach ($data as $datum) {
+            $results[] = $this->serializer->denormalize($datum, Type::class);
+        }
+
+        return $results;
+    }
 }


### PR DESCRIPTION
- add a method to retrieve types as we do it for collections, designers, etc. in filters (since type has its own index now)
- add an endpoint to suggest media watermarks
- edit the tags suggest endpoint to use the language query param instead of the locale. This is needed when you want to get results in all languages
