### PR TITLE
Individuals feature

### DIFF
--- a/Manager/IndividualManager.php
+++ b/Manager/IndividualManager.php
@@ -12,6 +12,7 @@
 namespace Tagwalk\ApiClientBundle\Manager;
 
 use GuzzleHttp\RequestOptions;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Serializer;
@@ -168,7 +169,7 @@ class IndividualManager
      */
     public function create(Individual $individual): ?Individual
     {
-        $apiResponse = $this->apiProvider->request('POST', '/api/individuals', [
+        $apiResponse = $this->apiProvider->request(Request::METHOD_POST, '/api/individuals', [
             RequestOptions::HTTP_ERRORS => false,
             RequestOptions::JSON => $this->serializer->normalize($individual, null, ['write' => true])
         ]);
@@ -194,7 +195,7 @@ class IndividualManager
 
     public function update(Individual $individual): ?Individual
     {
-        $apiResponse = $this->apiProvider->request('PUT', '/api/individuals/' . $individual->getSlug(), [
+        $apiResponse = $this->apiProvider->request(Request::METHOD_PUT, '/api/individuals/' . $individual->getSlug(), [
             RequestOptions::HTTP_ERRORS => false,
             RequestOptions::JSON => $this->serializer->normalize($individual, null, ['write' => true])
         ]);
@@ -212,6 +213,17 @@ class IndividualManager
         }
 
         return $this->serializer->denormalize($data, Individual::class);
+    }
+
+    public function toggleStatus(string $slug): bool
+    {
+        $apiResponse = $this->apiProvider->request(
+            Request::METHOD_PATCH,
+            sprintf('/api/individuals/%s/status', $slug),
+            [RequestOptions::HTTP_ERRORS => false]
+        );
+
+        return $apiResponse->getStatusCode() === Response::HTTP_OK;
     }
 
     public function getLastErrors(): array

--- a/Manager/IndividualManager.php
+++ b/Manager/IndividualManager.php
@@ -25,14 +25,9 @@ class IndividualManager
     public const DEFAULT_SORT = 'name:asc';
     public const DEFAULT_MODEL = 'true';
 
-    /**
-     * @var ApiProvider
-     */
-    protected $apiProvider;
+    protected ApiProvider $apiProvider;
 
-    /**
-     * @var Serializer
-     */
+    /** @var Serializer */
     protected $serializer;
 
     /**
@@ -40,24 +35,12 @@ class IndividualManager
      */
     public $lastCount;
 
-    /**
-     * @param ApiProvider          $apiProvider
-     * @param SerializerInterface  $serializer
-     */
-    public function __construct(
-        ApiProvider $apiProvider,
-        SerializerInterface $serializer
-    ) {
+    public function __construct(ApiProvider $apiProvider, SerializerInterface $serializer)
+    {
         $this->apiProvider = $apiProvider;
         $this->serializer = $serializer;
     }
 
-    /**
-     * @param string      $slug
-     * @param null|string $language
-     *
-     * @return Individual|null
-     */
     public function get(string $slug, ?string $language = null): ?Individual
     {
         $individual = null;
@@ -66,23 +49,20 @@ class IndividualManager
             RequestOptions::HTTP_ERRORS => false,
             RequestOptions::QUERY       => $query,
         ]);
+
         if ($apiResponse->getStatusCode() === Response::HTTP_OK) {
             /** @var Individual $individual */
-            $individual = $this->serializer->deserialize((string) $apiResponse->getBody(), Individual::class, JsonEncoder::FORMAT);
+            $individual = $this->serializer->deserialize(
+                (string) $apiResponse->getBody(),
+                Individual::class,
+                JsonEncoder::FORMAT
+            );
         }
 
         return $individual;
     }
 
     /**
-     * @param string|null $language
-     * @param int         $from
-     * @param int         $size
-     * @param string      $sort
-     * @param string      $status
-     * @param string      $model
-     * @param bool        $denormalize
-     *
      * @return array|Individual[]
      */
     public function list(
@@ -101,8 +81,10 @@ class IndividualManager
             RequestOptions::QUERY       => $query,
             RequestOptions::HTTP_ERRORS => false,
         ]);
+
         if ($apiResponse->getStatusCode() === Response::HTTP_OK) {
             $data = json_decode((string) $apiResponse->getBody(), true);
+
             if ($denormalize) {
                 foreach ($data as $datum) {
                     $individuals[] = $this->serializer->denormalize($datum, Individual::class);
@@ -110,17 +92,13 @@ class IndividualManager
             } else {
                 $individuals = $data;
             }
+
             $this->lastCount = (int) $apiResponse->getHeaderLine('X-Total-Count');
         }
 
         return $individuals;
     }
 
-    /**
-     * @param string $status
-     *
-     * @return int
-     */
     public function count(string $status = self::DEFAULT_STATUS): int
     {
         $count = 0;
@@ -131,6 +109,7 @@ class IndividualManager
             ],
             RequestOptions::HTTP_ERRORS => false,
         ]);
+
         if ($apiResponse->getStatusCode() === Response::HTTP_OK) {
             $count = (int) $apiResponse->getHeaderLine('X-Total-Count');
         }
@@ -138,12 +117,6 @@ class IndividualManager
         return $count;
     }
 
-    /**
-     * @param string      $prefix
-     * @param string|null $language
-     *
-     * @return array
-     */
     public function suggest(string $prefix, string $language = null): array
     {
         $individuals = [];
@@ -152,6 +125,7 @@ class IndividualManager
             RequestOptions::HTTP_ERRORS => false,
             RequestOptions::QUERY       => $query,
         ]);
+
         if ($apiResponse->getStatusCode() === Response::HTTP_OK) {
             $individuals = json_decode((string) $apiResponse->getBody(), true);
         }
@@ -160,12 +134,6 @@ class IndividualManager
     }
 
     /**
-     * @param string|null $city
-     * @param string|null $season
-     * @param string|null $designers
-     * @param string|null $tags
-     * @param string|null $language
-     *
      * @return Individual[]
      */
     public function listFiltersStreet(
@@ -181,6 +149,7 @@ class IndividualManager
             RequestOptions::HTTP_ERRORS => false,
             RequestOptions::QUERY       => $query,
         ]);
+        
         if ($apiResponse->getStatusCode() === Response::HTTP_OK) {
             $data = json_decode((string) $apiResponse->getBody(), true);
             foreach ($data as $datum) {

--- a/Manager/IndividualManager.php
+++ b/Manager/IndividualManager.php
@@ -152,7 +152,7 @@ class IndividualManager
             RequestOptions::HTTP_ERRORS => false,
             RequestOptions::QUERY       => $query,
         ]);
-        
+
         if ($apiResponse->getStatusCode() === Response::HTTP_OK) {
             $data = json_decode((string) $apiResponse->getBody(), true);
             foreach ($data as $datum) {

--- a/Model/Individual.php
+++ b/Model/Individual.php
@@ -72,6 +72,16 @@ class Individual extends AbstractDocument
     private $agencies;
 
     /**
+     * @Assert\Type("string")
+     */
+    private ?string $firstName = null;
+
+    /**
+     * @Assert\Type("string")
+     */
+    private ?string $lastName = null;
+
+    /**
      * @return bool
      */
     public function isModel(): bool
@@ -227,6 +237,30 @@ class Individual extends AbstractDocument
     public function setAgencies(?array $agencies): self
     {
         $this->agencies = $agencies;
+
+        return $this;
+    }
+
+    public function getFirstName(): ?string
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(?string $firstName): self
+    {
+        $this->firstName = $firstName;
+
+        return $this;
+    }
+
+    public function getLastName(): ?string
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName(?string $lastName): self
+    {
+        $this->lastName = $lastName;
 
         return $this;
     }

--- a/Utils/Constants/IndividualGender.php
+++ b/Utils/Constants/IndividualGender.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tagwalk\ApiClientBundle\Utils\Constants;
+
+class IndividualGender extends Constants
+{
+    const FEMALE = 'female';
+    const MALE = 'male';
+    const OTHER = 'other';
+}

--- a/Utils/FormErrorsMapper.php
+++ b/Utils/FormErrorsMapper.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tagwalk\ApiClientBundle\Utils;
+
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\String\UnicodeString;
+
+class FormErrorsMapper
+{
+    public static function mapApiErrorsToForm(FormInterface $form, array $errors): void
+    {
+        foreach ($errors as $propertyPath => $error) {
+            $property = self::findProperty($form, $propertyPath);
+
+            if ($property instanceof FormInterface) {
+                $error = new FormError($error);
+                $property->addError($error);
+
+                continue;
+            }
+
+            $error = new FormError($propertyPath . ': ' . $error);
+            $form->addError($error);
+        }
+    }
+
+    private static function findProperty(FormInterface $form, string $propertyPath): ?FormInterface
+    {
+        if ($form->has($propertyPath) === true) {
+            return $form->get($propertyPath);
+        }
+
+        $propertyPath = self::toSnakeCase($propertyPath);
+
+        if ($form->has($propertyPath) === true) {
+            return $form->get($propertyPath);
+        }
+
+        return null;
+    }
+
+    private static function toSnakeCase(string $toConvert): string
+    {
+        $toConvert = new UnicodeString($toConvert);
+
+        return $toConvert->snake();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     "symfony/serializer": "^4.2 || ^5.0",
     "symfony/property-info": "^4.2 || ^5.0",
     "symfony/routing": "^4.2 || ^5.0",
-    "symfony/cache": "^4.2 || ^5.0"
+    "symfony/cache": "^4.2 || ^5.0",
+    "symfony/string": "^5.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5",


### PR DESCRIPTION
- quelques ajouts utiles / nécessaires pour la gestion des `individuals` via le BO
- ajout d'un petit service `FormErrorsMapper` qui permet de récupérer les erreurs API et de les mapper automatiquement à un formulaire Symfony pour qu'elles s'affichent sur les champs en erreur. Fini les erreurs qui veulent rien dire 🥳