### PR TITLE
Remove PagePosition cause PageSection exists

### DIFF
--- a/Utils/Constants/PagePosition.php
+++ b/Utils/Constants/PagePosition.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Tagwalk\ApiClientBundle\Utils\Constants;
-
-class PagePosition extends Constants
-{
-    public const HEADER = 'header';
-    public const FOOTER = 'footer';
-}


### PR DESCRIPTION
J'avais remplacé `PagePosition` par `PageSection`, sans doute un résidu de ma boulette quand j'avais mergé des trucs de la maison du lin dans la release de Chanel.